### PR TITLE
Support for reading the page map

### DIFF
--- a/src/CallSites.hpp
+++ b/src/CallSites.hpp
@@ -22,26 +22,28 @@
 #ifndef _CALLSITE_HPP__
 #define _CALLSITE_HPP__
 #include "AddrRange.hpp"
+class PageMapReader;
 
 class CallSite : public AddrRange
    {
    std::string        _filename;
    unsigned           _lineNo;
    public:
-      CallSite(unsigned long long startAddr, unsigned long long endAddr, const std::string& filename, int lineNo) :
-         AddrRange(startAddr, endAddr), _filename(filename), _lineNo(lineNo){}
+      CallSite(unsigned long long startAddr, unsigned long long endAddr, const std::string& filename, int lineNo, unsigned long long rss) :
+         AddrRange(startAddr, endAddr, rss), _filename(filename), _lineNo(lineNo) {}
       virtual void clear()
          {
          AddrRange::clear();
          _filename.clear();
          _lineNo = 0;
          }
-      virtual int rangeType() const { return CALLSITE_RANGE; }
+      virtual int rangeType() const override { return CALLSITE_RANGE; }
+      virtual RangeCategories getRangeCategory() const override { return CALLSITE; }
    protected:
       virtual void print(std::ostream& os) const;
    }; //  AddrRange
 
-void readCallSitesFile(const char *filename, std::vector<CallSite>& callSites);
+void readCallSitesFile(const char *filename, std::vector<CallSite>& callSites, PageMapReader *pageMapReader);
 
 
 #endif // _CALLSITE_HPP__

--- a/src/MemoryEntry.hpp
+++ b/src/MemoryEntry.hpp
@@ -33,10 +33,10 @@
 class MemoryEntry
    {
    public:
-      AddrRange            _addrRange;
-      unsigned long long   _rss;
-      std::string          _details;
-      std::string          _protection;
+      AddrRange          _addrRange;
+      unsigned long long _rss;
+      std::string        _details;
+      std::string        _protection;
       // The following two fields are sorted lists of heterogenous objects derived from AddrRange
       // To be able to call the correct 'print' function based on the type of the object
       // we must store pointers
@@ -60,7 +60,7 @@ class MemoryEntry
       const std::list<const AddrRange*> getOverlappingRanges() const { return _overlappingRanges; }
       unsigned long long sizeKB() const { return _addrRange.sizeKB(); } // !! result in KB
       unsigned long long size() const { return _addrRange.size(); }
-      unsigned long long getResidentSize() const { return _rss; } // result in KB
+      unsigned long long getResidentSizeKB() const { return _rss; } // result in KB
       unsigned long long gapKB(const MemoryEntry& toOther) const { return _addrRange.gapKB(toOther.getAddrRange()); }
       const std::string& getDetailsString() const { return _details; }
       const std::string& getProtectionString() const { return _protection; }
@@ -97,7 +97,7 @@ struct MemoryEntryRssLessThan : public std::binary_function<MemoryEntry, MemoryE
    {
    bool operator() (const MemoryEntry& m1, const MemoryEntry& m2) const
       {
-      return (m1.getResidentSize() < m2.getResidentSize());
+      return (m1.getResidentSizeKB() < m2.getResidentSizeKB());
       }
    };
 

--- a/src/PageMapSupport.cpp
+++ b/src/PageMapSupport.cpp
@@ -1,0 +1,116 @@
+// Support fo readinf /proc/PID/pagemap file and determining which pages are
+// present in physical memory
+#include <stdio.h>  // printf, snprintf
+#include <fcntl.h> // open, O_RDONLY
+#include <errno.h> // errno
+#include <inttypes.h> // uint64_t
+#include <unistd.h> // sysconf, pread
+#include <string.h> // strerror
+#include <stdexcept> // runtime_error
+#include <iostream> // cerr
+#include "PageMapSupport.hpp"
+
+
+typedef struct __attribute__ ((__packed__)) {
+    union {
+        uint64_t pmd;
+        uint64_t page_frame_number : 55;
+        struct {
+            uint64_t swap_type: 5;
+            uint64_t swap_offset: 50;
+            uint64_t soft_dirty: 1;
+            uint64_t exclusive: 1;
+            uint64_t zero: 4;
+            uint64_t file_page: 1;
+            uint64_t swapped: 1;
+            uint64_t present: 1;
+        };
+    };
+} pmd_t;
+
+PageMapReader::PageMapReader(int pid): _pid(pid)
+   {
+   // Determine the page size on the system
+   _pageSize = sysconf(_SC_PAGE_SIZE);
+   if (_pageSize < 0)
+      {
+      throw std::runtime_error("cannot read page size with sysconf");
+      }
+
+   // form filename
+   snprintf(_pagemapPath, sizeof(_pagemapPath), "/proc/%d/pagemap", pid);
+
+   int pagemapfd = open(_pagemapPath, O_RDONLY);
+   if (pagemapfd < 0)
+      {
+      std::cerr << "Cannot open pagemap file: " << _pagemapPath << std::endl;
+      std::cerr << "Verify that PID exists and that we have read permission on the file." << std::endl;
+      std::cerr << "Error: " << strerror(errno) << std::endl;
+      throw std::runtime_error("");
+      }
+   }
+
+PageMapReader::~PageMapReader()
+   {
+   close(_pagemapfd);
+   }
+
+unsigned long long PageMapReader::computeRssForAddrRange(unsigned long long startAddr, unsigned long long endAddr)
+   {
+   if (startAddr >= endAddr)
+      throw std::runtime_error("invalid address range");
+
+   unsigned long long rss = 0;
+
+   // Align the start/end address to the page boundary
+   unsigned long long startAligned = startAddr & ~(_pageSize - 1);
+   unsigned long long endAligned = (endAddr + _pageSize - 1) & ~(_pageSize - 1);
+
+   // Read the contribution of the first page which may not be entirely used by this AddrRange
+   pmd_t pmd;
+   if (pread(_pagemapfd, &pmd.pmd, sizeof(pmd.pmd), (off_t)((startAligned / _pageSize) * sizeof(pmd))) != sizeof(pmd))
+      {
+      // Is the process still alive?
+      throw std::runtime_error("cannot read pagemap file: " + std::string(_pagemapPath) + std::string(strerror(errno)));
+      }
+   if (pmd.pmd != 0 && pmd.present)
+      {
+      if (endAddr <= startAligned + _pageSize)
+         {
+         // The range si within the first page
+         rss += endAddr - startAddr;
+         return rss;
+         }
+      else
+         {
+         rss += startAligned + _pageSize - startAddr;
+         }
+      }
+   // Read the contribution of the last page which may not be entirely used by this AddrRange
+   if (pread(_pagemapfd, &pmd.pmd, sizeof(pmd.pmd), (off_t)(((endAligned - _pageSize) / _pageSize) * sizeof(pmd))) != sizeof(pmd))
+      {
+      // Is the process still alive?
+      throw std::runtime_error("cannot read pagemap file: " + std::string(_pagemapPath) + std::string(strerror(errno)));
+      }
+   if (pmd.pmd != 0 && pmd.present)
+      {
+      rss += endAddr - (endAligned - _pageSize);
+      }
+
+   // Read the contribution of all the other pages
+   for (unsigned long long i = startAligned + _pageSize; i < endAligned - _pageSize; i += _pageSize)
+      {
+      pmd_t pmd;
+      // read at given offset
+      if (pread(_pagemapfd, &pmd.pmd, sizeof(pmd.pmd), (off_t)((i / _pageSize) * sizeof(pmd))) != sizeof(pmd))
+         {
+         // Is the process still alive?
+         throw std::runtime_error("cannot read pagemap file: " + std::string(_pagemapPath) + std::string(strerror(errno)));
+         }
+      if (pmd.pmd != 0 && pmd.present)
+         {
+         rss += _pageSize;
+         }
+      } // end for
+   return rss;
+   }

--- a/src/PageMapSupport.hpp
+++ b/src/PageMapSupport.hpp
@@ -1,0 +1,17 @@
+#ifndef PAGEMAPSUPPORT_HPP_
+#define PAGEMAPSUPPORT_HPP_
+
+class PageMapReader
+   {
+   int _pid; // PID of the process for which we want to rea the pagemap
+   long _pageSize; // page size of the system
+   char _pagemapPath[64]; // buffer for holding the path to the pagemap file
+   int _pagemapfd; // file descriptor for the pagemap file
+
+   public:
+   PageMapReader(int pid);
+   ~PageMapReader();
+   unsigned long long computeRssForAddrRange(unsigned long long startAddr, unsigned long long endAddr);
+   };
+
+#endif /* PAGEMAPSUPPORT_HPP_ */

--- a/src/vmmap.cpp
+++ b/src/vmmap.cpp
@@ -65,7 +65,7 @@ bool tokenizeVmmapLine(const string& line, vector<string>& tokens)
 
 // This is used for vmmap files in text format where fields start at fixed positions
 // The positions of these fields can be given by the postion of the headings
-// We use an array of these postions as input 
+// We use an array of these postions as input
 bool tokenizeVmmapTextLine(const string& line, vector<string>& tokens, const vector<size_t>& fieldPositions)
    {
    size_t lineSize = line.size();
@@ -94,7 +94,7 @@ bool tokenizeVmmapTextLine(const string& line, vector<string>& tokens, const vec
 #endif
          continue;
          }
-       
+
       // Read field by extracting substring bewteen startPos and endPos
       // and strip leading and trailing spaces
       string token = line.substr(startPosInLine, endPosInLine - startPosInLine);
@@ -151,7 +151,7 @@ void readVmmapTextFile(const char *vmmapFilename, vector<VmmapEntry>& vmmaps)
       cout << "readVmmapFile looking at :" << line << endl;
 #endif
       size_t startPos = line.find("Address");
-    
+
       if (std::string::npos != startPos)
          {
          fieldPositions.push_back(startPos);
@@ -249,11 +249,11 @@ void readVmmapTextFile(const char *vmmapFilename, vector<VmmapEntry>& vmmaps)
       // skip empty lines or lines that do not start with some character (subblock start with ampty space)
       if (line.find_first_not_of(" \t\n\r") != 0)
          continue;
-     
+
 #ifdef DEBUG
       cout << "readVmmapEntry looking at line " << lineNo << " with " << line.size() << " characters: " << line << endl;
 #endif
-     
+
       std::vector<std::string> tokens; // we should do tokens(13)
 
       if (!tokenizeVmmapTextLine(line, tokens, fieldPositions))
@@ -309,7 +309,7 @@ void readVmmapTextFile(const char *vmmapFilename, vector<VmmapEntry>& vmmaps)
       vmmaps.push_back(entry);
 
       virtSize += entry.sizeKB();
-      rssSize += entry.getResidentSize();
+      rssSize += entry.getResidentSizeKB();
       }
    myfile.close();
    cout << std::dec << "Total virtual size: " << virtSize << " kB. Total rss:" << rssSize << " kB." << endl;
@@ -419,7 +419,7 @@ void readVmmapCsvFile(const char *vmmapFilename, vector<VmmapEntry>& vmmaps)
       vmmaps.push_back(entry);
 
       virtSize += entry.sizeKB();
-      rssSize += entry.getResidentSize();
+      rssSize += entry.getResidentSizeKB();
       }
    myfile.close();
    cout << std::dec << "Total virtual size: " << virtSize << " kB. Total rss:" << rssSize << " kB." << endl;


### PR DESCRIPTION
The smaps file gives us the RSS for block memory allocations, but this is a summary. If several j9segments are included in an smap we don't know how much each contributes to RSS, so we have to estimate, using a proportional approach: we consider their RSS contribution to be proportional to their virtual size. This commit improves the situations by adding teh ability to read the pagemap file which shows which pages are in physical memory and which are not. To use this feature we must be running as root and the process whose footprint we analyze must still be running.

This commit also changes how parameters are passed to the program: rather than assuming parameters are given in a precise order, we added one letter option parameters:
"-j javacore_file -s smaps_file -c callsites_file -p PID"