### PR TITLE
SCC filename detection

### DIFF
--- a/src/FootprintAnalysis.cpp
+++ b/src/FootprintAnalysis.cpp
@@ -502,6 +502,7 @@ int main(int argc, char* argv[])
    const char *javacoreFilename = nullptr;
    const char *callsitesFilename = nullptr;
    const char *smapsFilename = nullptr;
+   std::string sccCachePath;
    int pid = 0;
    bool verbose = false;
    while ((opt = getopt(argc, argv, "c:i:j:ps:v")) != -1)
@@ -541,7 +542,23 @@ int main(int argc, char* argv[])
    // If PID is given, open the page map file
    PageMapReader *pageMapReader = pid ? new PageMapReader(pid) : nullptr;
 
-   // Read the smaps file
+
+   //===================== Javacore processing ============================
+   // This needs to be done before smaps processing because it computes
+   // the mapped file name for SCC
+   vector<J9Segment> segments; // must not become out-of-scope until I am done with the maps
+   vector<ThreadStack> threadStacks;
+
+   readJavacore(javacoreFilename, segments, threadStacks, sccCachePath);
+   SmapEntry::setSccCachePath(sccCachePath);
+   cout << "Found SCC file path: " << sccCachePath << std::endl;
+#ifdef DEBUG
+   // let's print all segments
+   cout << "Print segments:\n";
+   for (vector<J9Segment>::iterator it = segments.begin(); it != segments.end(); ++it)
+      cout << *it << endl;
+#endif
+   //====================== smaps file processing ======================
    vector<MapEntry> sMaps;
 #ifdef WINDOWS_FOOTPRINT
    readVmmapFile(smapsFilename, sMaps);
@@ -549,19 +566,6 @@ int main(int argc, char* argv[])
    readSmapsFile(smapsFilename, sMaps);
 #endif
 
-
-
-   //===================== Javacore processing ============================
-   vector<J9Segment> segments; // must not become out-of-scope until I am done with the maps
-   vector<ThreadStack> threadStacks;
-
-   readJavacore(javacoreFilename, segments, threadStacks, pageMapReader);
-#ifdef DEBUG
-   // let's print all segments
-   cout << "Print segments:\n";
-   for (vector<J9Segment>::iterator it = segments.begin(); it != segments.end(); ++it)
-      cout << *it << endl;
-#endif
    // Annotate maps with j9segments
    annotateMapWithSegments(sMaps, segments);
    annotateMapWithThreadStacks(sMaps, threadStacks);

--- a/src/Javacore.cpp
+++ b/src/Javacore.cpp
@@ -102,6 +102,41 @@ void ThreadStack::print(std::ostream& os) const
       " size=" << setfill(' ') << std::dec << setw(5) << sizeKB() << " KB";
    }
 
+void javacoreParseSCC(ifstream& myfile, int& lineNo, std::string &sccCachePath)
+   {
+   string line;
+   bool sharedClassesSectionFound = false;
+   while (std::getline(myfile, line))
+      {
+      lineNo++;
+      if (!sharedClassesSectionFound)
+         {
+         // Continue to search for the beginning of the SCC section
+         if (line.find("SHARED CLASSES subcomponent dump routine") != std::string::npos)
+            sharedClassesSectionFound = true;
+         continue;
+         }
+      if (line.find("0SECTION") != std::string::npos)
+         {
+         // This is the last section we are interested in
+         break;
+         }
+      //2SCLTEXTCMDT           acmeairscc                    CR                       Memory mapped file       /tmp/C290M17F1A64P_acmeairscc_G45L00
+      size_t pos = line.find("Memory mapped file");
+      if (pos != std::string::npos)
+         {
+         std::string tail = line.substr(pos + strlen("Memory mapped file"));
+         vector<string> tokens;
+         tokenize(tail, tokens);
+         if (!tokens.empty())
+            {
+            sccCachePath = tokens[0];
+            break;
+            }
+         }
+      }
+   }
+
 void javacoreParseStack(ifstream& myfile, int& lineNo, vector<ThreadStack>& threadStacks)
    {
    string line;
@@ -180,7 +215,7 @@ void javacoreParseStack(ifstream& myfile, int& lineNo, vector<ThreadStack>& thre
  * Read the javacore file and extract the memory segments and thread stacks
  * The output is stored in the segments and threadStacks vectors
 */
-void readJavacore(const char * javacoreFilename, vector<J9Segment>& segments, vector<ThreadStack>& threadStacks, PageMapReader *pageMapReader)
+void readJavacore(const char * javacoreFilename, vector<J9Segment>& segments, vector<ThreadStack>& threadStacks, string& sccCachePath)
    {
    cout << "Reading javacore file: " << string(javacoreFilename) << endl;
    // Open the file
@@ -288,6 +323,8 @@ void readJavacore(const char * javacoreFilename, vector<J9Segment>& segments, ve
          }
       } // end while
    javacoreParseStack(myfile, lineNo, threadStacks);
+   javacoreParseSCC(myfile, lineNo, sccCachePath);
+   // Note that if the SCC section is not present, we will reach the end of the file
    myfile.close();
    cout << "Reading of segments from javacore file finished\n";
    }

--- a/src/Javacore.hpp
+++ b/src/Javacore.hpp
@@ -93,7 +93,7 @@ class ThreadStack : public  AddrRange
    }; // J9Segment
 
 J9Segment::SegmentType determineSegmentType(const std::string& line);
-void readJavacore(const char * javacoreFilename, std::vector<J9Segment>& segments, std::vector<ThreadStack>& threadStacks, PageMapReader *pagemapReader);
+void readJavacore(const char * javacoreFilename, std::vector<J9Segment>& segments, std::vector<ThreadStack>& threadStacks, std::string& sccCachePath);
 
 
 #endif // _J9_SEGMENT_HPP__

--- a/src/smap.cpp
+++ b/src/smap.cpp
@@ -174,7 +174,8 @@ int parseSmapsMainLine(string line, SmapEntry &entry)
    try
       {
       // Line starts with an address range
-      std::cmatch result; //start    -  end        protection     offset      device major:minor   inode     file
+      // 7f957b000000-7f957b001000 rw-s 00000000 fd:00 269418052                  /opt/IBM/OL-25.0.0.6/liberty/usr/servers/.classCache/C290M17F1A64P_liberty-root_G45L00
+      std::cmatch result;              //start    -  end        protection     offset      device major:minor   inode     file
       static const std::regex pattern("([0-9a-f]+)-([0-9a-f]+) (\\S\\S\\S\\S) ([0-9a-f]+) ([0-9a-f]+:[0-9a-f]+) (\\d+)\\s*(\\S*)");
 
       if (std::regex_search(line.c_str(), result, pattern))
@@ -186,11 +187,9 @@ int parseSmapsMainLine(string line, SmapEntry &entry)
          entry._details.assign(result[7]);
          if (entry.isMapForSharedLibrary())
             entry.setPurpose(SmapEntry::DLL);
-         if (entry.isMapForThreadStack())
+         else if (entry.isMapForThreadStack())
             entry.setPurpose(SmapEntry::STACK);
-         if (entry.getDetailsString().find("javasharedresources") != string::npos || // found
-             entry.getDetailsString().find("classCache") != string::npos ||
-             entry.getDetailsString().find(".scc") != string::npos)
+         else if (entry.isMapForSCC())
             entry.setPurpose(SmapEntry::SCC);
          return 0;
          }
@@ -433,6 +432,12 @@ bool SmapEntry::isMapForSharedLibrary() const
 bool SmapEntry::isMapForThreadStack() const
    {
    return (getDetailsString().find("[stack") == 0); // check if it starts with [stack
+   }
+
+//---------------------------------------------------------------
+bool SmapEntry::isMapForSCC() const
+   {
+   return !_sccCachePath.empty() && getDetailsString() == _sccCachePath;
    }
 
 //--------------------------------------------------------

--- a/src/smap.hpp
+++ b/src/smap.hpp
@@ -76,6 +76,8 @@ class SmapEntry : public MemoryEntry
       SmapPurpose _purpose;
       //bool _mapForJavaHeap; // may turn to 'true' when we discover the smap is used for Java heap
    public:
+      static void setSccCachePath(const std::string &sccCachePath) { _sccCachePath = sccCachePath; }
+      static const std::string geSccCachePath() { return _sccCachePath; }
       SmapEntry() { clear(); }
       virtual void clear()
          {
@@ -88,9 +90,11 @@ class SmapEntry : public MemoryEntry
       void setPurpose(SmapPurpose purpose);
       bool isMapForSharedLibrary() const;
       bool isMapForThreadStack() const;
+      bool isMapForSCC() const;
    protected:
       virtual void print(std::ostream& os) const;
    private:
+      inline static std::string _sccCachePath;
       inline static bool endsWith(const std::string & str, const std::string & suffix)
          {
          return suffix.size() <= str.size() && std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());


### PR DESCRIPTION
We now get the name of the mapped file for the SCC from javacore and use that to find the entries that correspond to the SCC in the smaps.